### PR TITLE
Parse UA string

### DIFF
--- a/kobo/version.go
+++ b/kobo/version.go
@@ -62,7 +62,7 @@ func ParseKoboUAString(ua string) (version, id string, err error) {
 	if len(m) != 3 {
 		return "", "", errors.New("could not parse UA string")
 	}
-	idInt, err := strconv.ParseInt(strings.TrimLeft(m[1], "0"), 10, 32)
+	idInt, err := strconv.Atoi(m[1])
 	if err != nil {
 		return "", "", errors.New("could not parse device id")
 	}

--- a/kobo/version.go
+++ b/kobo/version.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -53,4 +54,17 @@ func ParseKoboAffiliate(kpath string) (affiliate string, err error) {
 		return "", errors.New("could not parse affiliate.conf")
 	}
 	return m[1], nil
+}
+
+// ParseKoboUAString parses a web browser UA string for Kobo ID and version info
+func ParseKoboUAString(ua string) (version, id string, err error) {
+	m := regexp.MustCompile(`.+\(Kobo Touch (\d+)/(\d+\.\d+.\d+)\)`).FindStringSubmatch(ua)
+	if len(m) != 3 {
+		return "", "", errors.New("could not parse UA string")
+	}
+	idInt, err := strconv.ParseInt(strings.TrimLeft(m[1], "0"), 10, 32)
+	if err != nil {
+		return "", "", errors.New("could not parse device id")
+	}
+	return m[2], fmt.Sprintf("00000000-0000-0000-0000-%012d", idInt), nil
 }

--- a/kobo/version.go
+++ b/kobo/version.go
@@ -56,7 +56,7 @@ func ParseKoboAffiliate(kpath string) (affiliate string, err error) {
 	return m[1], nil
 }
 
-// ParseKoboUAString parses a web browser UA string for Kobo ID and version info
+// ParseKoboUAString parses a web browser UA string for Kobo ID and version info.
 func ParseKoboUAString(ua string) (version, id string, err error) {
 	m := regexp.MustCompile(`.+\(Kobo Touch (\d+)/(\d+\.\d+.\d+)\)`).FindStringSubmatch(ua)
 	if len(m) != 3 {

--- a/kobo/version_test.go
+++ b/kobo/version_test.go
@@ -68,7 +68,7 @@ func TestParseKoboAffiliate(t *testing.T) {
 }
 
 func TestParseKoboUAString(t *testing.T) {
-	tests := []struct {
+	for _, tt := range []struct {
 		name         string
 		ua           string
 		expectedVers string
@@ -85,8 +85,7 @@ func TestParseKoboUAString(t *testing.T) {
 			ua:           "Mozilla/5.0 (Linux; Android 8.0.0; SM-G930F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36",
 			expectedVers: "", expectedID: "", expectedErr: errors.New("could not parse UA string"),
 		},
-	}
-	for _, tt := range tests {
+	} {
 		t.Run(tt.name, func(t *testing.T) {
 			vers, id, err := ParseKoboUAString(tt.ua)
 			if vers != tt.expectedVers {

--- a/kobo/version_test.go
+++ b/kobo/version_test.go
@@ -1,6 +1,7 @@
 package kobo
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -63,6 +64,41 @@ func TestParseKoboAffiliate(t *testing.T) {
 		}
 	}); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestParseKoboUAString(t *testing.T) {
+	tests := []struct {
+		name         string
+		ua           string
+		expectedVers string
+		expectedID   string
+		expectedErr  error
+	}{
+		{
+			name:         "Kobo H2O UA",
+			ua:           "Mozilla/5.0 (Linux; U; Android 2.0; en-us;) AppleWebKit/538.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/538.1 (Kobo Touch 0370/4.20.14622)",
+			expectedVers: "4.20.14622", expectedID: "00000000-0000-0000-0000-000000000370", expectedErr: nil,
+		},
+		{
+			name:         "Desktop Chrome UA",
+			ua:           "Mozilla/5.0 (Linux; Android 8.0.0; SM-G930F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36",
+			expectedVers: "", expectedID: "", expectedErr: errors.New("could not parse UA string"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vers, id, err := ParseKoboUAString(tt.ua)
+			if vers != tt.expectedVers {
+				t.Errorf("unexpected vers, want '%s' got '%s'\n", tt.expectedVers, vers)
+			}
+			if id != tt.expectedID {
+				t.Errorf("unexpected ID, want '%s' got '%s'\n", tt.expectedID, id)
+			}
+			if (err != tt.expectedErr) && (err != nil && tt.expectedErr != nil) && (err.Error() != tt.expectedErr.Error()) {
+				t.Errorf("unexpected err, want '%v' got '%v'\n", tt.expectedErr, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
I found myself needing to parse the UA string from the Kobo web browser, and I thought it might be useful to have this functionality in koboutils.

It turns out the Kobo web browser helpfully sends the kobo device version and firmware version, in the form of `Mozilla/5.0 (Linux; U; Android 2.0; en-us;) AppleWebKit/538.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/538.1 (Kobo Touch 0370/4.20.14622)`, so it's easy to parse.

And yes, I've added a couple of tests. I'm trying to get better at adding tests to my code...

