### PR TITLE
Obtain Device PPI

### DIFF
--- a/kobo/device.go
+++ b/kobo/device.go
@@ -419,7 +419,7 @@ func (d Device) DisplayPPI() int {
 	case DeviceMini:
 		return 200
 	case DeviceAura, DeviceGlo, DeviceAuraEdition2v1, DeviceAuraEdition2v2:
-		return 213
+		return 212
 	case DeviceAuraHD, DeviceAuraH2O, DeviceAuraH2OEdition2v1, DeviceAuraH2OEdition2v2:
 		return 265
 	case DeviceClaraHD, DeviceLibraH2O, DeviceAuraONE, DeviceForma, DeviceGloHD, DeviceAuraONELimitedEdition, DeviceForma32:

--- a/kobo/device.go
+++ b/kobo/device.go
@@ -411,7 +411,7 @@ func (d Device) StorageGB() int {
 	panic("unknown device")
 }
 
-// DisplayPPI returns the display Pixels Per Inch (PPI) of a Device
+// DisplayPPI returns the display Pixels Per Inch (PPI) of a Device.
 func (d Device) DisplayPPI() int {
 	switch d {
 	case DeviceTouchAB, DeviceTouchC, DeviceTouch2:

--- a/kobo/device.go
+++ b/kobo/device.go
@@ -410,3 +410,20 @@ func (d Device) StorageGB() int {
 	}
 	panic("unknown device")
 }
+
+// DisplayPPI returns the display Pixels Per Inch (PPI) of a Device
+func (d Device) DisplayPPI() int {
+	switch d {
+	case DeviceTouchAB, DeviceTouchC, DeviceTouch2:
+		return 167
+	case DeviceMini:
+		return 200
+	case DeviceAura, DeviceGlo, DeviceAuraEdition2v1, DeviceAuraEdition2v2:
+		return 213
+	case DeviceAuraHD, DeviceAuraH2O, DeviceAuraH2OEdition2v1, DeviceAuraH2OEdition2v2:
+		return 265
+	case DeviceClaraHD, DeviceLibraH2O, DeviceAuraONE, DeviceForma, DeviceGloHD, DeviceAuraONELimitedEdition, DeviceForma32:
+		return 300
+	}
+	panic("unknown device")
+}

--- a/kobo/device_test.go
+++ b/kobo/device_test.go
@@ -72,6 +72,7 @@ func TestSwitchCases(t *testing.T) {
 			d.Name,
 			d.StorageGB,
 			d.String,
+			d.DisplayPPI,
 		} {
 			if panics(fn) {
 				t.Errorf("%s: %s panics", d, reflect.ValueOf(fn))


### PR DESCRIPTION
I thought another useful addition to koboutils would be to add the ability to get return nominal PPI for each device.

I've added it as another SwitchCase style method to the Device type, and updated the `TestSwitchCases` test.

Values were retrieved from https://en.wikipedia.org/wiki/Kobo_eReader although I've chosen one nominal value where there were slight differences in the same class (same screen size and resolution) of device.